### PR TITLE
Fix Error for a Non-logged-in user Creating a Comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,15 +1,21 @@
 class CommentsController < ApplicationController
   def create
-    @post_id = params[:post_id]
-    @post = Post.find(params[:post_id])
-    @user = current_user
-    @comments = current_user.comments.create(:post_id => @post_id, :user_id => @user.id, :body => comment_params[:body])
-    if @comments.save
-      flash[:notice] = "Comment was saved."
-      redirect_to url_for(:action=>"show", :controller=>"posts", :format=>"26", :id=>@post.id , :topic_id=>@post.topic_id)
+    if current_user == nil
+      flash[:error] = "Log in first if you want to create a comment"
+      redirect_to '/users/sign_in'      
     else
-      flash[:error] = "There was an error saving the post. Please try again."
-      redirect_to '/topics'
+      puts "--- current_user = #{current_user} ---"
+      @post_id = params[:post_id]
+      @post = Post.find(params[:post_id])
+      @user = current_user
+        @comments = current_user.comments.create(:post_id => @post_id, :user_id => @user.id, :body => comment_params[:body])
+      if @comments.save
+        flash[:notice] = "Comment was saved."
+        redirect_to url_for(:action=>"show", :controller=>"posts", :format=>"26", :id=>@post.id , :topic_id=>@post.topic_id)
+      else
+        flash[:error] = "There was an error saving the post. Please try again."
+        redirect_to '/topics'
+      end
     end
   end
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,14 +1,12 @@
 class CommentsController < ApplicationController
   def create
-    if current_user == nil
+    if current_user.nil?
       flash[:error] = "Log in first if you want to create a comment"
       redirect_to '/users/sign_in'      
     else
-      puts "--- current_user = #{current_user} ---"
-      @post_id = params[:post_id]
       @post = Post.find(params[:post_id])
       @user = current_user
-        @comments = current_user.comments.create(:post_id => @post_id, :user_id => @user.id, :body => comment_params[:body])
+      @comments = current_user.comments.create(:post_id => @post.id, :user_id => @user.id, :body => comment_params[:body])
       if @comments.save
         flash[:notice] = "Comment was saved."
         redirect_to url_for(:action=>"show", :controller=>"posts", :format=>"26", :id=>@post.id , :topic_id=>@post.topic_id)


### PR DESCRIPTION
Without this fix, an error occurs when a user who is not logged in attempts to create a comment.
This change prevents the error, and displays a message saying "Log in first if you want to create a comment".
